### PR TITLE
feat: Added tests workflow and moved setup doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 lua-resty-casbin is an authorization plugin/middleware for OpenResty, based on [lua-casbin](https://github.com/casbin/lua-casbin/).
 
+## Installing OpenResty
+You can follow [this guide](https://blog.openresty.com/en/ubuntu20-or-install/) to install OpenResty on Ubuntu 20.04 if you have not yet installed it.
+
 ## Installation
 
 If you do not have LuaRocks installed for OpenResty then install it by:
@@ -20,6 +23,18 @@ sudo make
 sudo make install
 ```
 
+**NOTE**: 
+- This is assuming OpenResty (not the executable) is installed at `/usr/local/`, if it isn't so - replace `/usr/local/` with file path you have installed it in.
+- Also assumed is that LuaJIT version is `2.1.0-beta3`, you can check which LuaJIT version it is by doing: `cd /usr/local/openresty/luajit/share/` and then `ls`. It will list a luajit folder like `luajit-2.1.0-beta3`, the suffix here is `jit-2.1.0-beta3`. If this isn't so, replace the suffix accordingly.
+
+Then install Casbin's system dependencies by:
+```
+sudo apt update
+sudo apt install gcc libpcre3 libpcre3-dev
+```
+
+**NOTE**: If you use `yum` you could use `pcre` and `pcre-devel` for PCRE.
+
 Then install Casbin's latest current release (v1.11.0) using:
 
 ```
@@ -27,7 +42,7 @@ sudo /usr/local/openresty/luajit/bin/luarocks install https://raw.githubusercont
 
 ```
 
-(For detailed setup instructions, check it [here](https://github.com/casbin/lua-casbin/blob/master/Setup-OpenResty.md))
+**NOTE**: Here too the LuaRocks has its executable at `/usr/local/openresty/luajit/bin/luarocks`, if you have it installed somewhere else for OpenResty replace with that instead.
 
 
 ## Usage
@@ -94,6 +109,95 @@ The authorization determines a request based on `{subject, object, action}`, whi
 2. `object`: the URL path for the web resource like "dataset1/item1"
 3. `action`: HTTP method like GET, POST, PUT, DELETE, or the high-level actions you defined like "read-file", "write-blog"
 For how to write authorization policy and other details, please refer to the [Casbin's documentation](https://casbin.org/).
+
+## Example (without the middleware)
+
+You can use Casbin without the middleware as per your authorization design, this is a sample example for that. You can create a lua module for OpenResty applications as shown [here](https://blog.openresty.com/en/or-lua-module/) or add it to your existing lua module:
+
+- In the file where you want to use Casbin, use `local Enforcer = require("casbin")` inside the `content_by_lua_block`. Here is a sample describing usage for basic model/policy and ABAC model/policy:
+
+**Basic model/policy example (nginx.conf file)**
+```
+worker_processes 1;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    lua_package_path "$prefix/lua/?.lua;;";
+
+    server {
+        listen 8080 reuseport;
+
+        location / {
+            default_type text/plain;
+            content_by_lua_block {
+                local Enforcer = require("casbin")
+                local model  = "examples/basic_model.conf" -- The model file path
+                local policy  = "examples/basic_policy.csv" -- The policy file path
+                
+                local e = Enforcer:new(model, policy) -- The Casbin Enforcer
+                ngx.say("The result is:")
+                ngx.say(e:enforce("alice", "data1", "read")) -- The enforce function with its arguments
+            }
+        }
+    }
+}
+```
+
+**NOTE**: To use this example, you need to create an `examples` directory at the top level of your application `/` along with the `conf` directory. And then copy the [basic_model.conf](https://raw.githubusercontent.com/casbin/lua-casbin/master/examples/basic_model.conf) and [basic_policy.csv](https://raw.githubusercontent.com/casbin/lua-casbin/master/examples/basic_policy.csv) to that `examples` directory.
+
+**ABAC model/policy example (nginx.conf file)**
+```
+worker_processes 1;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    lua_package_path "$prefix/lua/?.lua;;";
+
+    server {
+        listen 8080 reuseport;
+
+        location / {
+            default_type text/plain;
+            content_by_lua_block {
+                local Enforcer = require("casbin")
+                local model  = "examples/abac_rule_model.conf"
+    		local policy  = "examples/abac_rule_policy.csv"
+    		local sub1 = {
+        		Name = "Alice",
+        		Age = 16
+    		}
+    		local sub2 = {
+        		Name = "Bob",
+        		Age = 20
+    		}
+    		local sub3 = {
+        		Name = "Alice",
+        		Age = 65
+    		}
+    		local e = Enforcer:new(model, policy)
+    		ngx.say("The result is:")
+    		ngx.say(e:enforce(sub2, "/data1", "read"))
+            }
+        }
+    }
+}
+```
+
+**NOTE**: Similar to the former example to use this, you need to create an `examples` directory at the top level of your application `/` along with the `conf` directory. And then copy the [abac_rule_model.conf](https://raw.githubusercontent.com/casbin/lua-casbin/master/examples/abac_model.conf) and [abac_rule_policy.csv](https://raw.githubusercontent.com/casbin/lua-casbin/master/examples/abac_rule_policy.csv) to that `examples` directory.
+
+Then use `sudo openresty -p $PWD/` to start the server and use `curl http://127.0.0.1:8080/` to fetch the page which for the above examples should output in:
+```
+The result is:
+true
+```
+
+You can check other examples [here](https://github.com/casbin/lua-casbin/blob/master/tests/main/enforcer_spec.lua) and the Built-In Functions currently supported [here](https://github.com/casbin/lua-casbin/blob/master/src/model/FunctionMap.lua).
 
 ## Getting Help
 

--- a/middleware_test.lua
+++ b/middleware_test.lua
@@ -1,0 +1,32 @@
+local http = require("socket.http")
+
+local function getHTTPCode(page, username, HTTPMethod)
+    local _, code, _, _ = http.request{url = "http://127.0.0.1:8080" .. page, headers = {["username"] = username}, method = HTTPMethod}
+    return code
+end
+
+describe("Middleware Tests", function ()
+    it("Homepage Tests", function ()
+        assert.is.Same(getHTTPCode("/", "anonymous", "GET"), 200)
+        assert.is.Same(getHTTPCode("/", "alice", "GET"), 200)
+        assert.is.Same(getHTTPCode("/", "anonymous", "POST"), 403)
+        assert.is.Same(getHTTPCode("/", "alice", "POST"), 200)
+        assert.is.Same(getHTTPCode("/", "alice", "PUT"), 200)
+    end)
+
+    it("Resource Tests", function ()
+        assert.is.Same(getHTTPCode("/resource1", "anonymous", "GET"), 403)
+        assert.is.Same(getHTTPCode("/resource1", "alice", "GET"), 200)
+        assert.is.Same(getHTTPCode("/resource1", "anonymous", "POST"), 403)
+        assert.is.Same(getHTTPCode("/resource1", "alice", "POST"), 200)
+        assert.is.Same(getHTTPCode("/dataset1/res1", "anonymous", "GET"), 403)
+        assert.is.Same(getHTTPCode("/dataset1/res1", "alice", "GET"), 200)
+    end)
+
+    it("RBAC Tests", function ()
+        assert.is.Same(getHTTPCode("/", "admin", "GET"), 200)
+        assert.is.Same(getHTTPCode("/", "alice", "GET"), 200)
+        assert.is.Same(getHTTPCode("/res", "admin", "POST"), 200)
+        assert.is.Same(getHTTPCode("/res", "alice", "POST"), 200)
+    end)
+end)


### PR DESCRIPTION
Fix: https://github.com/casbin-lua/lua-resty-casbin/issues/2

Fix: https://github.com/casbin-lua/lua-resty-casbin/issues/3

The workflow installs OpenResty and starts the server. And then we test using a separate Lua script that sends HTTP requests to the OR server.