### PR TITLE
feat: Added dist.ini for generating package for OPM

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,8 +24,6 @@ jobs:
         sudo cp openresty.list /etc/apt/sources.list.d/
         sudo apt-get update
         sudo apt-get -y install --no-install-recommends openresty
-        which openresty
-        openresty -V
     - name: Install LuaRocks and system dependencies
       run: |
         sudo apt update

--- a/casbin_middleware/CasbinMiddleware.lua
+++ b/casbin_middleware/CasbinMiddleware.lua
@@ -16,13 +16,19 @@ local Enforcer = require("casbin")
 
 CasbinMiddleware = {}
 
--- creates a new Casbin Middleware based on authz_model.conf and authz_policy.csv
-function CasbinMiddleware:new(next)
+--[[
+    - creates a new Casbin Middleware based on model path and policy path
+    - if no model passed in, uses the default authz_model.conf
+    - if no policy passed in, uses the default authz_policy.csv
+]]
+function CasbinMiddleware:new(next, modelPath, policyPath)
     local o = {}
     setmetatable(o, self)
     self.__index = self
 
-    local e = Enforcer:new("casbin_middleware/authz_model.conf", "casbin_middleware/authz_policy.csv")
+    if not modelPath then modelPath = "casbin_middleware/authz_model.conf" end
+    if not policyPath then policyPath = "casbin_middleware/authz_policy.csv" end
+    local e = Enforcer:new(modelPath, policyPath)
     o.enforcer = e
     o.next = next -- function called if request is authorised
     return o

--- a/dist.ini
+++ b/dist.ini
@@ -1,0 +1,9 @@
+name = lua-resty-casbin
+abstract = Casbin authorization plugin for OpenResty
+version = 1.0.1
+author = Casbin
+license = apache2
+repo_link = https://github.com/casbin-lua/lua-resty-casbin
+is_original = yes
+lib_dir = casbin_middleware
+main_module = casbin_middleware/CasbinMiddleware.lua

--- a/openresty_example/casbin_middleware/CasbinMiddleware.lua
+++ b/openresty_example/casbin_middleware/CasbinMiddleware.lua
@@ -16,13 +16,19 @@ local Enforcer = require("casbin")
 
 CasbinMiddleware = {}
 
--- creates a new Casbin Middleware based on authz_model.conf and authz_policy.csv
-function CasbinMiddleware:new(next)
+--[[
+    - creates a new Casbin Middleware based on model path and policy path
+    - if no model passed in, uses the default authz_model.conf
+    - if no policy passed in, uses the default authz_policy.csv
+]]
+function CasbinMiddleware:new(next, modelPath, policyPath)
     local o = {}
     setmetatable(o, self)
     self.__index = self
 
-    local e = Enforcer:new("casbin_middleware/authz_model.conf", "casbin_middleware/authz_policy.csv")
+    if not modelPath then modelPath = "casbin_middleware/authz_model.conf" end
+    if not policyPath then policyPath = "casbin_middleware/authz_policy.csv" end
+    local e = Enforcer:new(modelPath, policyPath)
     o.enforcer = e
     o.next = next -- function called if request is authorised
     return o

--- a/openresty_example/conf/nginx.conf
+++ b/openresty_example/conf/nginx.conf
@@ -6,7 +6,7 @@ events {
 
 http {
     init_by_lua_block {
-        require("casbin_middleware/middleware")
+        require("casbin_middleware/CasbinMiddleware")
         
         local function authorizedRequest()
             ngx.say("Authorized request")


### PR DESCRIPTION
Changes made:
- Changed the name of `middleware` to `CasbinMiddleware` so it can be used using `require("CasbinMiddleware")` after the package is installed using OPM.
- Changed the `CasbinMiddleware` function's params to support any model/policy files other than the example ones currently.

Also, to upload this we need to generate a build using `opm build` and upload it using `opm upload` which requires the GitHub username of the org and a personal access token of the owner of the org with scopes `user:email` and `read:org`. This should be saved at `~/.opmrc` file. More about this [here](https://opm.openresty.org/docs#file-opmrc). 
What can we do about this?
